### PR TITLE
Add `marker::combinable_imports` lint

### DIFF
--- a/src/custom.rs
+++ b/src/custom.rs
@@ -15,6 +15,6 @@ pub fn check_item<'ast>(cx: &'ast MarkerContext<'ast>, item: ast::ItemKind<'ast>
 /// Currently unused until the crate object is available after:
 /// <https://github.com/rust-marker/marker/issues/279>
 #[allow(dead_code)]
-pub fn check_crate<'ast>(cx: &'ast MarkerContext<'ast>, krate: ast::Crate<'ast>) {
+pub fn check_crate<'ast>(cx: &'ast MarkerContext<'ast>, krate: &ast::Crate<'ast>) {
     combinable_imports::check_crate(cx, krate);
 }

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -1,0 +1,20 @@
+//! This is the parent module for custom lints
+
+use marker_api::prelude::*;
+
+mod combinable_imports;
+
+pub fn lints() -> Vec<&'static Lint> {
+    vec![combinable_imports::COMBINABLE_IMPORTS]
+}
+
+pub fn check_item<'ast>(cx: &'ast MarkerContext<'ast>, item: ast::ItemKind<'ast>) {
+    combinable_imports::check_item(cx, item);
+}
+
+/// Currently unused until the crate object is available after:
+/// <https://github.com/rust-marker/marker/issues/279>
+#[allow(dead_code)]
+pub fn check_crate<'ast>(cx: &'ast MarkerContext<'ast>, krate: ast::Crate<'ast>) {
+    combinable_imports::check_crate(cx, krate);
+}

--- a/src/custom/combinable_imports.rs
+++ b/src/custom/combinable_imports.rs
@@ -30,7 +30,7 @@ pub fn check_item<'ast>(cx: &'ast MarkerContext<'ast>, item: ast::ItemKind<'ast>
     }
 }
 
-pub fn check_crate<'ast>(cx: &'ast MarkerContext<'ast>, krate: ast::Crate<'ast>) {
+pub fn check_crate<'ast>(cx: &'ast MarkerContext<'ast>, krate: &ast::Crate<'ast>) {
     check_items(cx, krate.items());
 }
 
@@ -40,8 +40,7 @@ pub fn check_items<'ast>(cx: &'ast MarkerContext<'ast>, items: &[ast::ItemKind<'
     for item in items {
         // Only select imports
         let import = if let ast::ItemKind::Use(import) = item
-            && let span = import.span()
-            && !span.is_from_expansion()
+            && !import.span().is_from_expansion()
         {
             import
         } else {
@@ -100,6 +99,8 @@ fn count_match(a: &[String], b: &[String]) -> usize {
 
 /// Checks if the two [`AstPathSegment`]s are the same or different.
 fn are_merged(a: &AstPathSegment<'_>, b: &AstPathSegment<'_>) -> bool {
+    // FIXME: These segments should have IDs instead. Comparing the
+    // spans is unnecessary hacky
     let a_span = a.ident().span();
     if let SpanSource::File(file) = a_span.source() {
         let a_start = file.to_file_pos(a_span.start());

--- a/src/custom/combinable_imports.rs
+++ b/src/custom/combinable_imports.rs
@@ -1,0 +1,116 @@
+use marker_api::{
+    ast::{AstPath, AstPathSegment},
+    prelude::*,
+    span::SpanSource,
+};
+
+marker_api::declare_lint! {
+    /// # What it does
+    /// It detects `use` items that could be combined.
+    ///
+    /// # Example
+    /// ```
+    /// use std::fs::File;
+    /// use std::vec::Vec;
+    /// ```
+    ///
+    /// Use instead:
+    /// ```
+    /// use std::{fs::File, vec::Vec};
+    /// ```
+    COMBINABLE_IMPORTS,
+    Warn,
+}
+
+pub fn check_item<'ast>(cx: &'ast MarkerContext<'ast>, item: ast::ItemKind<'ast>) {
+    if let ast::ItemKind::Mod(module) = item
+        && !item.span().is_from_expansion()
+    {
+        check_items(cx, module.items());
+    }
+}
+
+pub fn check_crate<'ast>(cx: &'ast MarkerContext<'ast>, krate: ast::Crate<'ast>) {
+    check_items(cx, krate.items());
+}
+
+pub fn check_items<'ast>(cx: &'ast MarkerContext<'ast>, items: &[ast::ItemKind<'ast>]) {
+    let mut namespaces: Vec<UseItemInfo<'_>> = vec![];
+
+    for item in items {
+        // Only select imports
+        let import = if let ast::ItemKind::Use(import) = item
+            && let span = import.span()
+            && !span.is_from_expansion()
+        {
+            import
+        } else {
+            continue;
+        };
+
+        // Find merge candidate
+        let segs = stringify_path(import.use_path());
+        let import_info = UseItemInfo { segs, import };
+        let candidate = namespaces
+            .iter()
+            .fold((None, 0), |prev_selection, candidate| {
+                compare_candidate(&import_info, prev_selection, candidate)
+            });
+
+        // Emit lint
+        if let (Some(other), _) = candidate {
+            cx.emit_lint(COMBINABLE_IMPORTS, import, "this import can be merged...")
+                .span_note("...with this one", other.import.span());
+        }
+
+        // Insert as a potential merge candidate
+        namespaces.push(import_info);
+    }
+}
+
+fn stringify_path(path: &AstPath<'_>) -> Vec<String> {
+    path.segments()
+        .iter()
+        .map(|seg| seg.ident().name().to_string())
+        .collect()
+}
+
+fn compare_candidate<'a, 'ast>(
+    import: &UseItemInfo<'ast>,
+    best: (Option<&'a UseItemInfo<'ast>>, usize),
+    candidate: &'a UseItemInfo<'ast>,
+) -> (Option<&'a UseItemInfo<'ast>>, usize) {
+    let (best_candidate, best_count) = best;
+    let ctn = count_match(&import.segs, &candidate.segs);
+    if ctn > best_count
+        && !are_merged(
+            &import.import.use_path().segments()[ctn - 1],
+            &candidate.import.use_path().segments()[ctn - 1],
+        )
+    {
+        (Some(candidate), ctn)
+    } else {
+        (best_candidate, best_count)
+    }
+}
+
+fn count_match(a: &[String], b: &[String]) -> usize {
+    a.iter().zip(b.iter()).take_while(|(x, y)| x == y).count()
+}
+
+/// Checks if the two [`AstPathSegment`]s are the same or different.
+fn are_merged(a: &AstPathSegment<'_>, b: &AstPathSegment<'_>) -> bool {
+    let a_span = a.ident().span();
+    if let SpanSource::File(file) = a_span.source() {
+        let a_start = file.to_file_pos(a_span.start());
+        let b_start = file.to_file_pos(b.ident().span().start());
+        a_start.column() == b_start.column() && a_start.line() == b_start.line()
+    } else {
+        false
+    }
+}
+
+struct UseItemInfo<'ast> {
+    segs: Vec<String>,
+    import: &'ast ast::UseItem<'ast>,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use marker_api::prelude::*;
 use marker_api::{LintPass, LintPassInfo, LintPassInfoBuilder};
 
 mod clippy;
+mod custom;
 
 #[derive(Default)]
 struct MyLintPass {}
@@ -12,10 +13,16 @@ marker_api::export_lint_pass!(MyLintPass);
 
 impl LintPass for MyLintPass {
     fn info(&self) -> LintPassInfo {
-        LintPassInfoBuilder::new(clippy::lints().into_boxed_slice()).build()
+        let mut lints = clippy::lints();
+        lints.append(&mut custom::lints());
+        LintPassInfoBuilder::new(lints.into_boxed_slice()).build()
     }
 
     fn check_expr<'ast>(&mut self, cx: &'ast MarkerContext<'ast>, expr: ast::ExprKind<'ast>) {
         clippy::check_expr(cx, expr);
+    }
+
+    fn check_item<'ast>(&mut self, cx: &'ast MarkerContext<'ast>, item: ast::ItemKind<'ast>) {
+        custom::check_item(cx, item);
     }
 }

--- a/tests/ui/combinable_imports.rs
+++ b/tests/ui/combinable_imports.rs
@@ -1,0 +1,34 @@
+#![feature(register_tool)]
+#![register_tool(marker)]
+#![allow(unused_imports)]
+
+mod example_1 {
+    use std::fs::File;
+    use std::vec::Vec;
+
+    use std::collections::BTreeMap;
+    #[allow(marker::combinable_imports)]
+    use std::collections::BTreeSet;
+}
+
+mod example_2 {
+    use std::{collections::BTreeMap, collections::BTreeSet};
+}
+
+mod example_3 {
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        fs::File,
+        vec::Vec,
+    };
+}
+
+/// False positive, waiting on <https://github.com/rust-marker/marker/issues/26>
+mod example_4 {
+    pub use std::fs::File;
+    use std::vec::Vec;
+}
+
+fn main() {
+    let _x = 18;
+}

--- a/tests/ui/combinable_imports.stderr
+++ b/tests/ui/combinable_imports.stderr
@@ -1,0 +1,51 @@
+warning: this import can be merged...
+ --> $DIR/combinable_imports.rs:7:5
+  |
+7 |     use std::vec::Vec;
+  |     ^^^^^^^^^^^^^^^^^^
+  |
+note: ...with this one
+ --> $DIR/combinable_imports.rs:6:5
+  |
+6 |     use std::fs::File;
+  |     ^^^^^^^^^^^^^^^^^^
+  = note: `#[warn(marker::combinable_imports)]` on by default
+
+warning: this import can be merged...
+ --> $DIR/combinable_imports.rs:9:5
+  |
+9 |     use std::collections::BTreeMap;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+note: ...with this one
+ --> $DIR/combinable_imports.rs:6:5
+  |
+6 |     use std::fs::File;
+  |     ^^^^^^^^^^^^^^^^^^
+
+warning: this import can be merged...
+  --> $DIR/combinable_imports.rs:15:38
+   |
+15 |     use std::{collections::BTreeMap, collections::BTreeSet};
+   |                                      ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: ...with this one
+  --> $DIR/combinable_imports.rs:15:15
+   |
+15 |     use std::{collections::BTreeMap, collections::BTreeSet};
+   |               ^^^^^^^^^^^^^^^^^^^^^
+
+warning: this import can be merged...
+  --> $DIR/combinable_imports.rs:29:5
+   |
+29 |     use std::vec::Vec;
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+note: ...with this one
+  --> $DIR/combinable_imports.rs:28:5
+   |
+28 |     pub use std::fs::File;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+
+warning: 4 warnings emitted
+


### PR DESCRIPTION
A small lint, to find `use` items that can be merged.

The implementation is a bit limited due to these API limitations:
* https://github.com/rust-marker/marker/issues/279
* https://github.com/rust-marker/marker/issues/26

Not much more to say. I'm looking forward to testing this lint on Marker itself :)